### PR TITLE
fix: remove deprecated homebrew/bundle tap

### DIFF
--- a/install/Brewfile
+++ b/install/Brewfile
@@ -1,5 +1,3 @@
-tap "homebrew/bundle"
-
 # core/dotfiles
 brew "coreutils"
 brew "stow"


### PR DESCRIPTION
The homebrew/bundle tap was deprecated and is now built into Homebrew core. Removing the tap line fixes the installation error.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)