### PR TITLE
Fix stow installation ordering on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ all: $(OS)
 
 # Selective installation targets
 minimal: check-deps oh-my-zsh link
-packages-only: check-deps brew-packages cask-apps
+packages-only: brew-packages cask-apps check-deps
 config-only: check-deps link
 linux-no-sudo: oh-my-zsh link-no-stow
 
-macos: check-deps sudo core-macos packages link duti
+macos: sudo core-macos packages check-deps link duti
 
 linux: check-deps core-linux link
 


### PR DESCRIPTION
This PR fixes the stow installation ordering issue reported in #1.

## Problem
The install.sh script was failing on Mac with "stow is required but not installed" because the Makefile was checking for dependencies before installing the packages that provide those dependencies.

## Solution
Reordered the Makefile targets to:
- Install packages first (including stow via Homebrew)
- Then check dependencies

This ensures stow is available when the dependency check runs.

Generated with [Claude Code](https://claude.ai/code)