### PR TITLE
fix: comprehensive Mac installation error fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,19 @@ export STOW_DIR = $(DOTFILES_DIR)
 export ACCEPT_EULA=Y
 
 # Check if required commands exist
-check-deps:
+check-deps: ensure-bin-executable
 	@echo "Checking dependencies..."
 	@command -v stow >/dev/null 2>&1 || { echo "Error: stow is required but not installed"; exit 1; }
 	@if [ "$(OS)" = "macos" ]; then \
 		command -v brew >/dev/null 2>&1 || { echo "Error: Homebrew is required but not installed"; exit 1; }; \
 	fi
 	@echo "All dependencies satisfied"
+
+# Ensure all bin scripts are executable
+ensure-bin-executable:
+	@echo "Ensuring bin scripts are executable..."
+	@chmod +x bin/* || { echo "Failed to make bin scripts executable"; exit 1; }
+	@echo "Bin scripts are now executable"
 
 all: $(OS)
 
@@ -109,6 +115,16 @@ brew:
 		curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o "$$temp_script" || { echo "Failed to download Homebrew installer"; exit 1; }; \
 		/bin/bash "$$temp_script" || { echo "Homebrew installation failed"; rm -f "$$temp_script"; exit 1; }; \
 		rm -f "$$temp_script"; \
+		echo "Homebrew installation completed. You may need to add it to your PATH."; \
+		if [ "$(OS)" = "macos" ]; then \
+			if [ -x "/opt/homebrew/bin/brew" ]; then \
+				echo "Homebrew installed at /opt/homebrew (ARM64)"; \
+			elif [ -x "/usr/local/bin/brew" ]; then \
+				echo "Homebrew installed at /usr/local (Intel)"; \
+			else \
+				echo "Warning: Homebrew installation completed but brew not found in expected locations"; \
+			fi; \
+		fi; \
 	else \
 		echo "Homebrew already installed"; \
 	fi

--- a/bin/is-arm64
+++ b/bin/is-arm64
@@ -1,0 +1,9 @@
+#!/bin/zsh
+
+## This script is used to determine if the current Mac is ARM64 (Apple Silicon). It returns 0 if it is, 1 if it is not.
+
+if [[ "$(uname -m)" == "arm64" ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -223,9 +223,10 @@ setup_git_config() {
     sed -i.bak "s|PLACEHOLDER_GITHUB_USER|$github_user|" config/git/config || { log_error "Failed to update GitHub user"; exit 1; }
     
     # Set OS-appropriate credential helper
-    if [[ "$OS" == "macos" ]]; then
+    local os=$(detect_os)
+    if [[ "$os" == "macos" ]]; then
         sed -i.bak "s|helper = osxkeychain|helper = osxkeychain|" config/git/config
-    elif [[ "$OS" == "linux" ]]; then
+    elif [[ "$os" == "linux" ]]; then
         sed -i.bak "s|helper = osxkeychain|helper = store|" config/git/config
     fi
     


### PR DESCRIPTION
Comprehensive fixes for Mac installation errors reported in issue #12.

## Key Fixes:
- Add missing bin/is-arm64 script for ARM64 Mac detection
- Fix undefined OS variable in install.sh credential helper setup
- Add Homebrew installation verification with path detection
- Add ensure-bin-executable target to prevent permission issues
- Improve error handling and logging for Mac-specific installations

These changes address the root causes of Mac installation failures, particularly on ARM64 (M1/M2) systems.

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)